### PR TITLE
resolve indexed event data

### DIFF
--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -44,15 +44,14 @@ describe("Hume721a test", () => {
     const balanceOwner = await hume721a.balanceOf(signer1.address);
     assert(balanceOwner.eq(quantity), "wrong quantity minted");
 
-    /// I would test Transfer event using correct start token id if the event data wasn't `indexed`:
-    // const { from, to, tokenId } = await getEventArgs(
-    //   hume721a.deployTransaction,
-    //   "Transfer",
-    //   hume721a,
-    // ) as TransferEvent["args"];
-    // assert(from === ethers.constants.AddressZero, "wrong minter");
-    // assert(to === signer1.address, "wrong mintee");
-    // assert(tokenId.eq(1), "wrong start token id");
+    const { from, to, tokenId } = await getEventArgs(
+      hume721a.deployTransaction,
+      "Transfer",
+      hume721a,
+    ) as TransferEvent["args"];
+    assert(from === ethers.constants.AddressZero, "wrong minter");
+    assert(to === signer1.address, "wrong mintee");
+    assert(tokenId.eq(1), "wrong start token id");
 
     // sets vars
     assert((await hume721a.baseURI()) === baseURI, "did not set baseURI");

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -318,7 +318,11 @@ export const getEventArgs = async (
     throw new Error(`Could not find event ${eventName} at address ${address}`);
   }
 
-  return contract.interface.decodeEventLog(eventName, eventObj.data);
+  return contract.interface.decodeEventLog(
+    eventName,
+    eventObj.data,
+    eventObj.topics
+  );
 };
 
 export function BNtoInt(x: BigNumber): number {


### PR DESCRIPTION
Small fix for `getEventArgs` function to resolve indexed event data, allowing us to test `Transfer` event